### PR TITLE
Add support from group switching

### DIFF
--- a/SwitchItem.qml
+++ b/SwitchItem.qml
@@ -57,12 +57,12 @@ Item {
 
 	function getImage(switchState, type) {
 		switch (type) {
+			case 'group':
+				if(switchState != "on" && switchState != "off")
+					break;
 			case 'light':
 			case 'switch':
-				{
-					return (switchState === "off") ? "./drawables/bulb_off.png" : "./drawables/bulb_on.png"
-					break;
-				}
+				return (switchState === "off") ? "./drawables/bulb_off.png" : "./drawables/bulb_on.png"
 			default:
 				return "./drawables/sensor.png"
 		}
@@ -72,8 +72,13 @@ Item {
 		anchors.fill: parent
 		onPressed: {
 			switchItem.state = "down"
-			
+
 			switch (type) {
+				case 'group':
+					{
+						if(switchState != "on" && switchState != "off")
+							break;
+					}
 				case 'light':
 				case 'switch':
 					{
@@ -82,7 +87,7 @@ Item {
 						break;
 					}
 				default:
-					
+					break;
 			}
 
 		}


### PR DESCRIPTION
This change allows switch- or light groups (actually any group with a status that has an "on" or "off"-value) to be switched. It's a quick-and-dirty way to get this working. In the future it'll be better to check the entities inside a group to closer match [how the Home Assistant front end works](https://www.home-assistant.io/components/group/).